### PR TITLE
only clean contents of staged environment on failure

### DIFF
--- a/tasks/cleanup.sh
+++ b/tasks/cleanup.sh
@@ -2,5 +2,5 @@
 set -x
 exec 2>&1
 
-sudo -u pe-puppet -H bash -c "rm -rf $PT_code_staging/environments/$PT_environment"
+sudo -u pe-puppet -H bash -c "rm -rf $PT_code_staging/environments/$PT_environment/{*,.*}"
 rm -f $PT_signature_location/$PT_environment/$PT_commit_hash.jwt


### PR DESCRIPTION
Completely removing the staged code-dir will cause file-sync to mark the previously deployed environment as 'expired' which results in it being purged from `/etc/puppetlabs/code/environments/<env_name>` the next time file-sync is triggered (ex. the next time IA gets ran). Simply removing the staged environments contents and leaving behind the parent directory is enough to prevent this behavior.